### PR TITLE
optimize hash join by supporting int hashmap (#11411)

### DIFF
--- a/pkg/common/hashmap/joinmap.go
+++ b/pkg/common/hashmap/joinmap.go
@@ -20,11 +20,12 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 )
 
-func NewJoinMap(sels [][]int32, expr *plan.Expr, mp *StrHashMap, hasNull bool, isDup bool) *JoinMap {
+func NewJoinMap(sels [][]int32, expr *plan.Expr, ihm *IntHashMap, shm *StrHashMap, hasNull bool, isDup bool) *JoinMap {
 	cnt := int64(1)
 	return &JoinMap{
 		cnt:     &cnt,
-		mp:      mp,
+		shm:     shm,
+		ihm:     ihm,
 		expr:    expr,
 		sels:    sels,
 		hasNull: hasNull,
@@ -35,10 +36,6 @@ func NewJoinMap(sels [][]int32, expr *plan.Expr, mp *StrHashMap, hasNull bool, i
 
 func (jm *JoinMap) Sels() [][]int32 {
 	return jm.sels
-}
-
-func (jm *JoinMap) Map() *StrHashMap {
-	return jm.mp
 }
 
 func (jm *JoinMap) Expr() *plan.Expr {
@@ -53,30 +50,75 @@ func (jm *JoinMap) IsDup() bool {
 	return jm.isDup
 }
 
+func (jm *JoinMap) NewIterator() Iterator {
+	if jm.shm == nil {
+		return &intHashMapIterator{
+			mp:      jm.ihm,
+			m:       jm.ihm.m,
+			ibucket: jm.ihm.ibucket,
+			nbucket: jm.ihm.nbucket,
+		}
+	} else {
+		return &strHashmapIterator{
+			mp:      jm.shm,
+			m:       jm.shm.m,
+			ibucket: jm.shm.ibucket,
+			nbucket: jm.shm.nbucket,
+		}
+	}
+}
+
 func (jm *JoinMap) Dup() *JoinMap {
-	m0 := &StrHashMap{
-		m:             jm.mp.m,
-		hashMap:       jm.mp.hashMap,
-		hasNull:       jm.mp.hasNull,
-		ibucket:       jm.mp.ibucket,
-		nbucket:       jm.mp.nbucket,
-		values:        make([]uint64, UnitLimit),
-		zValues:       make([]int64, UnitLimit),
-		keys:          make([][]byte, UnitLimit),
-		strHashStates: make([][3]uint64, UnitLimit),
+	if jm.shm == nil {
+		m0 := &IntHashMap{
+			m:       jm.ihm.m,
+			hashMap: jm.ihm.hashMap,
+			hasNull: jm.ihm.hasNull,
+			ibucket: jm.ihm.ibucket,
+			nbucket: jm.ihm.nbucket,
+			keys:    make([]uint64, UnitLimit),
+			keyOffs: make([]uint32, UnitLimit),
+			values:  make([]uint64, UnitLimit),
+			zValues: make([]int64, UnitLimit),
+			hashes:  make([]uint64, UnitLimit),
+		}
+		jm0 := &JoinMap{
+			ihm:     m0,
+			expr:    jm.expr,
+			sels:    jm.sels,
+			hasNull: jm.hasNull,
+			cnt:     jm.cnt,
+		}
+		if atomic.AddInt64(jm.dupCnt, -1) == 0 {
+			jm.ihm = nil
+			jm.sels = nil
+		}
+		return jm0
+	} else {
+		m0 := &StrHashMap{
+			m:             jm.shm.m,
+			hashMap:       jm.shm.hashMap,
+			hasNull:       jm.shm.hasNull,
+			ibucket:       jm.shm.ibucket,
+			nbucket:       jm.shm.nbucket,
+			values:        make([]uint64, UnitLimit),
+			zValues:       make([]int64, UnitLimit),
+			keys:          make([][]byte, UnitLimit),
+			strHashStates: make([][3]uint64, UnitLimit),
+		}
+		jm0 := &JoinMap{
+			shm:     m0,
+			expr:    jm.expr,
+			sels:    jm.sels,
+			hasNull: jm.hasNull,
+			cnt:     jm.cnt,
+		}
+		if atomic.AddInt64(jm.dupCnt, -1) == 0 {
+			jm.shm = nil
+			jm.sels = nil
+		}
+		return jm0
 	}
-	jm0 := &JoinMap{
-		mp:      m0,
-		expr:    jm.expr,
-		sels:    jm.sels,
-		hasNull: jm.hasNull,
-		cnt:     jm.cnt,
-	}
-	if atomic.AddInt64(jm.dupCnt, -1) == 0 {
-		jm.mp = nil
-		jm.sels = nil
-	}
-	return jm0
 }
 
 func (jm *JoinMap) IncRef(ref int64) {
@@ -95,13 +137,21 @@ func (jm *JoinMap) Free() {
 		jm.sels[i] = nil
 	}
 	jm.sels = nil
-	jm.mp.Free()
+	if jm.ihm != nil {
+		jm.ihm.Free()
+	} else {
+		jm.shm.Free()
+	}
 }
 
 func (jm *JoinMap) Size() int64 {
 	// TODO: add the size of the other JoinMap parts
-	if jm.mp == nil {
+	if jm.ihm == nil && jm.shm == nil {
 		return 0
 	}
-	return jm.mp.Size()
+	if jm.ihm != nil {
+		return jm.ihm.Size()
+	} else {
+		return jm.shm.Size()
+	}
 }

--- a/pkg/common/hashmap/types.go
+++ b/pkg/common/hashmap/types.go
@@ -70,7 +70,8 @@ type JoinMap struct {
 	sels   [][]int32
 	// push-down filter expression, possibly a bloomfilter
 	expr    *plan.Expr
-	mp      *StrHashMap
+	shm     *StrHashMap
+	ihm     *IntHashMap
 	hasNull bool
 
 	isDup bool

--- a/pkg/sql/colexec/anti/join.go
+++ b/pkg/sql/colexec/anti/join.go
@@ -103,7 +103,7 @@ func (ctr *container) build(ap *Argument, proc *process.Process, anal process.An
 		ctr.bat = bat
 		ctr.mp = bat.DupJmAuxData()
 		ctr.hasNull = ctr.mp.HasNull()
-		anal.Alloc(ctr.mp.Map().Size())
+		anal.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -162,7 +162,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	eligible := make([]int32, 0, hashmap.UnitLimit)
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i

--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
@@ -44,20 +45,36 @@ func Prepare(proc *process.Process, arg any) (err error) {
 	}
 
 	if ap.NeedHashMap {
-		if ap.ctr.mp, err = hashmap.NewStrMap(false, ap.Ibucket, ap.Nbucket, proc.Mp()); err != nil {
-			return err
-		}
 		ap.ctr.vecs = make([]*vector.Vector, len(ap.Conditions))
-
 		ctr := ap.ctr
 		ctr.evecs = make([]evalVector, len(ap.Conditions))
-		for i := range ctr.evecs {
+		ctr.keyWidth = 0
+		for i, expr := range ap.Conditions {
+			typ := expr.Typ
+			width := types.T(typ.Id).TypeLen()
+			// todo : for varlena type, always go strhashmap
+			if types.T(typ.Id).FixedLength() < 0 {
+				width = 128
+			}
+			ctr.keyWidth += width
 			ctr.evecs[i].executor, err = colexec.NewExpressionExecutor(proc, ap.Conditions[i])
 			if err != nil {
 				return err
 			}
 		}
+
+		if ctr.keyWidth <= 8 {
+			if ctr.intHashMap, err = hashmap.NewIntHashMap(false, ap.Ibucket, ap.Nbucket, proc.Mp()); err != nil {
+				return err
+			}
+		} else {
+			if ctr.strHashMap, err = hashmap.NewStrMap(false, ap.Ibucket, ap.Nbucket, proc.Mp()); err != nil {
+				return err
+			}
+		}
+
 	}
+
 	ap.ctr.bat = batch.NewWithSize(len(ap.Typs))
 	for i, typ := range ap.Typs {
 		ap.ctr.bat.Vecs[i] = vector.NewVec(typ)
@@ -79,8 +96,10 @@ func Call(idx int, proc *process.Process, arg any, isFirst bool, _ bool) (proces
 				ctr.cleanHashMap()
 				return process.ExecNext, err
 			}
-			if ap.ctr.mp != nil {
-				anal.Alloc(ap.ctr.mp.Size())
+			if ap.ctr.intHashMap != nil {
+				anal.Alloc(ap.ctr.intHashMap.Size())
+			} else if ap.ctr.strHashMap != nil {
+				anal.Alloc(ap.ctr.strHashMap.Size())
 			}
 			ctr.state = HandleRuntimeFilter
 
@@ -92,11 +111,16 @@ func Call(idx int, proc *process.Process, arg any, isFirst bool, _ bool) (proces
 		case Eval:
 			if ctr.bat != nil && ctr.bat.RowCount() != 0 {
 				if ap.NeedHashMap {
-					ctr.bat.AuxData = hashmap.NewJoinMap(ctr.sels, nil, ctr.mp, ctr.hasNull, ap.IsDup)
+					if ctr.keyWidth <= 8 {
+						ctr.bat.AuxData = hashmap.NewJoinMap(ctr.sels, nil, ctr.intHashMap, nil, ctr.hasNull, ap.IsDup)
+					} else {
+						ctr.bat.AuxData = hashmap.NewJoinMap(ctr.sels, nil, nil, ctr.strHashMap, ctr.hasNull, ap.IsDup)
+					}
 				}
 
 				proc.SetInputBatch(ctr.bat)
-				ctr.mp = nil
+				ctr.intHashMap = nil
+				ctr.strHashMap = nil
 				ctr.bat = nil
 				ctr.sels = nil
 			} else {
@@ -188,7 +212,12 @@ func (ctr *container) build(ap *Argument, proc *process.Process, anal process.An
 		return err
 	}
 
-	itr := ctr.mp.NewIterator()
+	var itr hashmap.Iterator
+	if ctr.keyWidth <= 8 {
+		itr = ctr.intHashMap.NewIterator()
+	} else {
+		itr = ctr.strHashMap.NewIterator()
+	}
 	count := ctr.bat.RowCount()
 
 	ctr.sels = make([][]int32, count)
@@ -201,13 +230,25 @@ func (ctr *container) build(ap *Argument, proc *process.Process, anal process.An
 
 		//preAlloc to improve performance and reduce memory reAlloc
 		if count > hashmap.HashMapSizeThreshHold && i == hashmap.HashMapSizeEstimate {
-			groupCount := ctr.mp.GroupCount()
-			rate := float64(groupCount) / float64(i)
-			hashmapCount := uint64(float64(count) * rate)
-			if hashmapCount > groupCount {
-				err = ctr.mp.PreAlloc(hashmapCount-groupCount, proc.Mp())
-				if err != nil {
-					return err
+			if ctr.keyWidth <= 8 {
+				groupCount := ctr.intHashMap.GroupCount()
+				rate := float64(groupCount) / float64(i)
+				hashmapCount := uint64(float64(count) * rate)
+				if hashmapCount > groupCount {
+					err = ctr.intHashMap.PreAlloc(hashmapCount-groupCount, proc.Mp())
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				groupCount := ctr.strHashMap.GroupCount()
+				rate := float64(groupCount) / float64(i)
+				hashmapCount := uint64(float64(count) * rate)
+				if hashmapCount > groupCount {
+					err = ctr.strHashMap.PreAlloc(hashmapCount-groupCount, proc.Mp())
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -52,7 +52,9 @@ type container struct {
 	evecs []evalVector
 	vecs  []*vector.Vector
 
-	mp *hashmap.StrHashMap
+	intHashMap *hashmap.IntHashMap
+	strHashMap *hashmap.StrHashMap
+	keyWidth   int // keyWidth is the width of hash columns, it determines which hash map to use.
 }
 
 type Argument struct {
@@ -103,8 +105,12 @@ func (ctr *container) cleanEvalVectors(mp *mpool.MPool) {
 }
 
 func (ctr *container) cleanHashMap() {
-	if ctr.mp != nil {
-		ctr.mp.Free()
-		ctr.mp = nil
+	if ctr.intHashMap != nil {
+		ctr.intHashMap.Free()
+		ctr.intHashMap = nil
+	}
+	if ctr.strHashMap != nil {
+		ctr.strHashMap.Free()
+		ctr.strHashMap = nil
 	}
 }

--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -108,7 +108,7 @@ func (ctr *container) build(proc *process.Process, anal process.Analyze) error {
 	if bat != nil {
 		ctr.bat = bat
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Map().Size())
+		anal.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -142,7 +142,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	mSels := ctr.mp.Sels()
 
 	count := bat.RowCount()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	rowCount := 0
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i

--- a/pkg/sql/colexec/left/join.go
+++ b/pkg/sql/colexec/left/join.go
@@ -105,7 +105,7 @@ func (ctr *container) build(ap *Argument, proc *process.Process, anal process.An
 	if bat != nil {
 		ctr.bat = bat
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Map().Size())
+		anal.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i
 		if n > hashmap.UnitLimit {

--- a/pkg/sql/colexec/mark/join.go
+++ b/pkg/sql/colexec/mark/join.go
@@ -192,7 +192,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i
 		if n > hashmap.UnitLimit {

--- a/pkg/sql/colexec/right/join.go
+++ b/pkg/sql/colexec/right/join.go
@@ -130,7 +130,7 @@ func (ctr *container) build(ap *Argument, proc *process.Process, analyze process
 		ctr.mp = bat.DupJmAuxData()
 		ctr.matched = &bitmap.Bitmap{}
 		ctr.matched.InitWithSize(bat.RowCount())
-		analyze.Alloc(ctr.mp.Map().Size())
+		analyze.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -216,7 +216,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 
 	rowCountIncrese := 0
 	for i := 0; i < count; i += hashmap.UnitLimit {

--- a/pkg/sql/colexec/rightanti/join.go
+++ b/pkg/sql/colexec/rightanti/join.go
@@ -128,7 +128,7 @@ func (ctr *container) build(ap *Argument, proc *process.Process, analyze process
 		ctr.mp = bat.DupJmAuxData()
 		ctr.matched = &bitmap.Bitmap{}
 		ctr.matched.InitWithSize(bat.RowCount())
-		analyze.Alloc(ctr.mp.Map().Size())
+		analyze.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -196,7 +196,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i
 		if n > hashmap.UnitLimit {

--- a/pkg/sql/colexec/rightsemi/join.go
+++ b/pkg/sql/colexec/rightsemi/join.go
@@ -130,7 +130,7 @@ func (ctr *container) build(ap *Argument, proc *process.Process, analyze process
 		ctr.mp = bat.DupJmAuxData()
 		ctr.matched = &bitmap.Bitmap{}
 		ctr.matched.InitWithSize(bat.RowCount())
-		analyze.Alloc(ctr.mp.Map().Size())
+		analyze.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -196,7 +196,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i
 		if n > hashmap.UnitLimit {

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -109,7 +109,7 @@ func (ctr *container) build(anal process.Analyze) error {
 	if bat != nil {
 		ctr.bat = bat
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Map().Size())
+		anal.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 
 	rowCountIncrease := 0
 	eligible := make([]int32, 0, hashmap.UnitLimit)

--- a/pkg/sql/colexec/single/join.go
+++ b/pkg/sql/colexec/single/join.go
@@ -116,7 +116,7 @@ func (ctr *container) build(ap *Argument, proc *process.Process, anal process.An
 	if bat != nil {
 		ctr.bat = bat
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Map().Size())
+		anal.Alloc(ctr.mp.Size())
 	}
 	return nil
 }
@@ -161,7 +161,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 
 	count := bat.RowCount()
 	mSels := ctr.mp.Sels()
-	itr := ctr.mp.Map().NewIterator()
+	itr := ctr.mp.NewIterator()
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i
 		if n > hashmap.UnitLimit {


### PR DESCRIPTION
hash join always use str hashmap. make it support int hashmap. this can reduce half the memory allocation and improve performance.

Approved by: @m-schen, @nnsgmsone

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: